### PR TITLE
Add missing "endevent" to FNISSMQuestScript.psc

### DIFF
--- a/SRC_OTHER/FNISSMQuestScript.psc
+++ b/SRC_OTHER/FNISSMQuestScript.psc
@@ -25,6 +25,7 @@ int property debuglevel = 0 auto
 event oninit()
 endevent
 event onupdate()
+endevent
 int function getanimindex(int[] percentar)
 endfunction
 int function getrandomanimation(actor akfemale)


### PR DESCRIPTION
While you may not need this particular script for DD NG, this fix might be helpful for anyone using this to compile other DD plugins.